### PR TITLE
Fix aiogram Bot init

### DIFF
--- a/app/init.py
+++ b/app/init.py
@@ -1,5 +1,6 @@
 import logging
 from aiogram import Bot, Dispatcher, types
+from aiogram.client.bot import DefaultBotProperties
 from aiogram.filters import CommandStart
 
 from .config import config
@@ -13,7 +14,10 @@ async def on_startup(bot: Bot):
 
 async def init() -> None:
     logging.basicConfig(level=logging.INFO)
-    bot = Bot(token=config.token, parse_mode=config.parse_mode)
+    bot = Bot(
+        token=config.token,
+        default=DefaultBotProperties(parse_mode=config.parse_mode),
+    )
     dp = Dispatcher()
 
     dp.message.middleware.register(LoggingMiddleware())


### PR DESCRIPTION
## Summary
- use DefaultBotProperties for parse mode

## Testing
- `python -m app.run` *(fails: ModuleNotFoundError: No module named 'aiogram')*


------
https://chatgpt.com/codex/tasks/task_e_686d0d310ac48320816d5ff1e50b8577